### PR TITLE
Logic to generate project structure

### DIFF
--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -28,9 +28,9 @@ const symbols = {
   vertical: '│   ',
 };
 
-// generateTree returns a string representing the "tree printout" of a file system made up of the
-// provided paths.
-const generateTree = (paths: string[]): string => {
+// generateTree returns a list of strings --- one string for each line of the output ---
+// representing the "tree printout" of a file system made up of the provided paths.
+const generateTree = (paths: string[]): string[] => {
   const outputAsLines: string[] = [];
   paths.forEach((path) => {
     // Find the number of '/' chars in the path
@@ -59,7 +59,7 @@ const generateTree = (paths: string[]): string => {
     outputAsLines.push(curLine);
   });
 
-  return outputAsLines.join('\n');
+  return outputAsLines;
 };
 
 export { ripOutPaths, generateTree };

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -33,7 +33,8 @@ const generateTree = (paths: string[]): string => {
     // of the project. We don't have to decorate this line of the output with
     // any │ or ├── symbols
     if (curDepth === 0) {
-      outputAsLines.push(path);
+      // Add a folder emoji before the directory name
+      outputAsLines.push(`📂 ${path}`);
       return;
     }
 
@@ -45,6 +46,8 @@ const generateTree = (paths: string[]): string => {
     }
     // Add a ├── symbol
     curLine += symbols.branch;
+    // Add a folder emoji before the directory name
+    curLine += '📂 ';
     // Add the name of the deepest directory
     const deepestDirName = path.substring(path.lastIndexOf('/') + 1);
     curLine += deepestDirName;

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -1,0 +1,20 @@
+import { GithubAPIResponseBody, GithubAPIFileObject } from "./types";
+
+// ripOutPaths condenses the response body from a Github API call to a list of directory paths.
+const ripOutPaths = (responseBody: GithubAPIResponseBody): string[] => responseBody.tree
+  .map((file: GithubAPIFileObject) => file.path) // Isolate the path from each object
+  .filter((path: string) => path.includes('/')) // Remove paths that don't include a directory
+  .map((path: string) => path.substring(0, path.lastIndexOf('/'))) // Trim off trailing file name
+  .filter((path: string) => path !== '') // Remove resulting empty strings from previous step
+  .reduce(
+    (finalListOfPaths: string[], path: string) => {
+      // Remove duplicate elements
+      if (finalListOfPaths.includes(path)) {
+        return finalListOfPaths;
+      }
+      return [...finalListOfPaths, path];
+    },
+    [], // Initial value for the reducer
+  );
+
+export default ripOutPaths;

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -17,6 +17,12 @@ const ripOutPaths = (responseBody: GithubAPIResponseBody): string[] => responseB
     [], // Initial value for the reducer
   );
 
+// formatDirName returns a Markdown relative link for the provided path, and sticks a folder emoji
+// at the beginning of the provided dirname.
+//
+// Helper func for generateTree().
+const formatDirName = (path: string, dirName: string): string => `📂 [${dirName}](./${path})`;
+
 const symbols = {
   branch: '├── ',
   vertical: '│   ',
@@ -34,7 +40,7 @@ const generateTree = (paths: string[]): string => {
     // any │ or ├── symbols
     if (curDepth === 0) {
       // Add a folder emoji before the directory name
-      outputAsLines.push(`📂 ${path}`);
+      outputAsLines.push(formatDirName(path, path));
       return;
     }
 
@@ -46,11 +52,9 @@ const generateTree = (paths: string[]): string => {
     }
     // Add a ├── symbol
     curLine += symbols.branch;
-    // Add a folder emoji before the directory name
-    curLine += '📂 ';
     // Add the name of the deepest directory
     const deepestDirName = path.substring(path.lastIndexOf('/') + 1);
-    curLine += deepestDirName;
+    curLine += formatDirName(path, deepestDirName);
 
     outputAsLines.push(curLine);
   });

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -17,4 +17,42 @@ const ripOutPaths = (responseBody: GithubAPIResponseBody): string[] => responseB
     [], // Initial value for the reducer
   );
 
-export default ripOutPaths;
+const symbols = {
+  branch: '├── ',
+  vertical: '│   ',
+};
+
+// generateTree returns a string representing the "tree printout" of a file system made up of the
+// provided paths.
+const generateTree = (paths: string[]): string => {
+  const outputAsLines: string[] = [];
+  paths.forEach((path) => {
+    // Find the number of '/' chars in the path
+    const curDepth = path.match(/\//g)?.length ?? 0;
+    // If there are no '/' chars in the path, then this directory is at the root
+    // of the project. We don't have to decorate this line of the output with
+    // any │ or ├── symbols
+    if (curDepth === 0) {
+      outputAsLines.push(path);
+      return;
+    }
+
+    // Build the current line in the overall output
+    let curLine = '';
+    // For all nested "levels" except for the deepest one, add a │ vertical bar
+    for (let i = 0; i < curDepth - 1; i += 1) {
+      curLine += symbols.vertical;
+    }
+    // Add a ├── symbol
+    curLine += symbols.branch;
+    // Add the name of the deepest directory
+    const deepestDirName = path.substring(path.lastIndexOf('/') + 1);
+    curLine += deepestDirName;
+
+    outputAsLines.push(curLine);
+  });
+
+  return outputAsLines.join('\n');
+};
+
+export { ripOutPaths, generateTree };

--- a/src/tree/types.ts
+++ b/src/tree/types.ts
@@ -1,0 +1,14 @@
+export interface GithubAPIFileObject {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
+  size: number;
+  url: string;
+}
+
+export interface GithubAPIResponseBody {
+  sha: string;
+  url: string;
+  tree: GithubAPIFileObject[];
+}


### PR DESCRIPTION
Closes #6 

Proposing to add a collection of functions which can ultimately convert the response body from the Github API endpoint that we're hitting to traverse the file structure of a public repo to a "tree printout" of that repo's directory structure.

### "Tree Printout" Features

The resulting "tree printout" that these functions can help you generate has the following features:

* Markdown relative links to each corresponding folder in the repo
* 📂 emojis in front of each directory name
    * is this really a feature lol

### Features Not Implemented

* No descriptions or comments about the inferred purpose of each directory
    * I imagine that we as a team can talk about which common directory "types" we'd like to support
    * This is also a "fringe" feature, and isn't super high-priority, so we can do it later