### PR TITLE
Add first draft of MarkdownDisplay component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3896,6 +3896,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -10511,6 +10519,15 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz",
+      "integrity": "sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==",
+      "requires": {
+        "copy-to-clipboard": "^3",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -12912,6 +12929,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
     "react": "^16.13.1",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "styled-components": "^5.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import MarkdownDisplay from './components/MarkdownDisplay';
 
 // Styles
 
@@ -20,6 +21,7 @@ const Column = styled.div`
 
 const App: React.FC = () => {
   const [url, setURL] = useState('Enter a Github Repo');
+  const [markdownDisplayContent, setMarkdownDisplayContent] = useState(['public', 'src']);
 
   const handleURLChange = (e: React.ChangeEvent<HTMLInputElement>) => setURL(e.target.value);
 
@@ -28,6 +30,7 @@ const App: React.FC = () => {
       <Column>
         <h1>SWEGGG</h1>
         <input type="text" value={url} onChange={handleURLChange} />
+        <MarkdownDisplay content={markdownDisplayContent} />
       </Column>
     </Container>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,117 +1,36 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const App: React.FC = () => <Input />;
+// Styles
 
-const Input: React.FC = () => {
-  const [url, setUrl] = useState(
-    'Enter a Github Repo',
-  );
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
 
-  const handleChange = (event) => setUrl(event.target.value);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Column = styled.div`
+  flex-direction: column;
+`;
+
+// Components
+
+const App: React.FC = () => {
+  const [url, setURL] = useState('Enter a Github Repo');
+
+  const handleURLChange = (e: React.ChangeEvent<HTMLInputElement>) => setURL(e.target.value);
 
   return (
     <Container>
-      <h1>SWEGGG</h1>
-      <input type="text" value={url} onChange={handleChange} />
-        <MarkDownDisplay>
-            <MarkDownTextDisplay>
-                <MarkDownTextContainerLight>
-                    <MarkDownTextWrapper>
-                        <MarkDownText>📂📄 Lorem Ipmsum</MarkDownText>
-                    </MarkDownTextWrapper>
-                    <DeleteContainer />
-                </MarkDownTextContainerLight>
-            </MarkDownTextDisplay>
-            <Copy>
-                <CopyButton>
-                    <CopyText>Copy</CopyText>
-                </CopyButton>
-            </Copy>
-        </MarkDownDisplay>
+      <Column>
+        <h1>SWEGGG</h1>
+        <input type="text" value={url} onChange={handleURLChange} />
+      </Column>
     </Container>
   );
 };
 
 export default App;
-
-const MarkDownTextWrapper = styled.div`
-  display: inline;
-`;
-
-const MarkDownText = styled.p`
-  font-family: Arial;
-  font-size: 16px;
-`;
-
-
-const MarkDownTextContainer = styled.div`
-  height: 25px;
-  padding: 0 5px;
-  flex: 1 0;
-  flex-direction: row;
-  justify-content: space-between;
-  
-  &:hover {
-    background-color: saddlebrown;
-  }
-`;
-
-const MarkDownTextContainerLight = styled(MarkDownTextContainer)`
-  background-color: white;
-`;
-
-const MarkDownTextContainerDark = styled(MarkDownTextContainer)`
-  background-color: red;
-`;
-
-const DeleteContainer = styled.div`
-  width: 10px;
-  height: 10px;
-  border-radius: 500px;
-  background-color: red;
-  float: right;
-  display: none;
-  ${MarkDownTextContainer}:hover & {
-    display: flex;
-  }
-`;
-
-const Container = styled.div`
-    background-color: aquamarine;
-    flex: 1 0;
-`;
-
-const MarkDownDisplay = styled.div`
-    width: 300px;
-    flex: 1 0;
-    background-color: grey;
-    box-shadow: 0px 10px 5px lightgray;
-    border-radius: 7px;
-`;
-
-const MarkDownTextDisplay = styled.div`
-    padding: 5px 0;
-    flex: 1 0;
-`;
-
-const Copy = styled.div`
-  height: 25px;
-  background-color: dimgrey;
-  border-bottom-left-radius: 7px;
-  border-bottom-right-radius: 7px;
-`;
-const CopyButton = styled.div`
-  height: 25px;
-  margin-left: auto;
-  background-color: darkgray;
-  width: 50px;
-  border-bottom-right-radius: 7px;
-`;
-
-const CopyText = styled.p`
-  text-align: center;
-  font-family: Arial;
-  font-size: 16px;
-  color: white;
-`;

--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import MarkdownDisplayLine from './MarkdownDisplayLine';
 
 // Styles
@@ -24,6 +25,9 @@ const MarkdownDisplay: React.FC<Props> = (props: Props) => (
         <MarkdownDisplayLine isOddNumberedLine={i % 2 === 1} content={line} />
       ))
     }
+    <CopyToClipboard text={props.content.join('\n')}>
+      <button type="submit">Copy to Clipboard</button>
+    </CopyToClipboard>
   </Card>
 );
 

--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -1,16 +1,30 @@
 import React from 'react';
+import styled from 'styled-components';
+import MarkdownDisplayLine from './MarkdownDisplayLine';
 
-// Component
+// Styles
+
+const Card = styled.div`
+  width: 100%;
+  padding: 2rem;
+  background: #212428;
+  color: white;
+`;
+
+// Components
 
 interface Props {
   content: string[];
 }
 
 const MarkdownDisplay: React.FC<Props> = (props: Props) => (
-  <>
-    <p>MarkdownDisplay component</p>
-    {props.content.map((line) => <p>{line}</p>)}
-  </>
+  <Card>
+    {
+      props.content.map((line, i) => (
+        <MarkdownDisplayLine isOddNumberedLine={i % 2 === 1} content={line} />
+      ))
+    }
+  </Card>
 );
 
 export default MarkdownDisplay;

--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+// Component
+
+interface Props {
+  content: string[];
+}
+
+const MarkdownDisplay: React.FC<Props> = (props: Props) => (
+  <>
+    <p>MarkdownDisplay component</p>
+    {props.content.map((line) => <p>{line}</p>)}
+  </>
+);
+
+export default MarkdownDisplay;

--- a/src/components/MarkdownDisplayLine.tsx
+++ b/src/components/MarkdownDisplayLine.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Styles
+
+const LightBGColor = styled.div`
+  padding: 0.25rem;
+  background: #414959;
+`;
+
+const DarkBGColor = styled.div`
+  padding: 0.25rem;
+  background: #212428;
+`;
+
+// Components
+
+interface Props {
+  isOddNumberedLine: boolean;
+  content: string;
+}
+
+const MarkdownDisplayLine: React.FC<Props> = (props: Props) => {
+  if (props.isOddNumberedLine) {
+    return (
+      <DarkBGColor>
+        {props.content}
+      </DarkBGColor>
+    );
+  }
+  return (
+    <LightBGColor>
+      {props.content}
+    </LightBGColor>
+  );
+};
+
+export default MarkdownDisplayLine;

--- a/src/index.css
+++ b/src/index.css
@@ -5,4 +5,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  background: aquamarine;
 }


### PR DESCRIPTION
Related to #9, but doesn't quite close it.

This PR introduces a `MarkdownDisplay` component on the front-end that displays the generated "tree printout" describing the directory structure of a public GitHub repo.

### Implemented Functionality

* Displays lines that are passed in through a list of strings as a prop
* "Copy to Clipboard" button is present, copying all of the contents displayed
    * Brought in [react-copy-to-clipboard](https://www.npmjs.com/package/react-copy-to-clipboard) for this
        * I bet you that there's a better way to implement this functionality that doesn't depend on a third-party module. What does everybody think?
    * Calls `.join('\n')` on the list of strings prop, then copies _that_ result to the user's clipboard

### Stuff Not Implemented

* It looks like 💩 atm
    * #10 is all about addressing this
![Screen Shot 2020-06-03 at 5 32 12 PM](https://user-images.githubusercontent.com/31291920/83691469-37ff3f00-a5c0-11ea-951f-db2d884c9418.png)
