### PR TITLE
Add descriptive comments to common directories in projects

### DIFF
--- a/src/tree/constants.ts
+++ b/src/tree/constants.ts
@@ -1,0 +1,45 @@
+export const symbols = {
+  branch: '├── ',
+  vertical: '│   ',
+};
+
+const commentLeader = '#';
+const srcDirComment = `${commentLeader} Source files`;
+const testDirComment = `${commentLeader} Test functions and procedures (often run automatically)`;
+const toolsDirComment = `${commentLeader} Miscellaneous helpers and utilities`;
+const docDirComment = `${commentLeader} Documentation files`;
+const binDirComment = `${commentLeader} Compiled files, or standalone executables`;
+const assetsDirComment = `${commentLeader} Supplemental assets or resources, or static files`;
+
+export const commonDirComments: Record<string, string> = {
+  // src dir variants
+  src: srcDirComment,
+  lib: srcDirComment,
+  app: srcDirComment,
+  pkg: srcDirComment,
+
+  // test dir variants
+  test: testDirComment,
+  tests: testDirComment,
+  spec: testDirComment,
+
+  // tools dir variants
+  tools: toolsDirComment,
+  tool: toolsDirComment,
+  util: toolsDirComment,
+
+  // doc dir variants
+  doc: docDirComment,
+  docs: docDirComment,
+
+  // bin dir variants
+  bin: binDirComment,
+  build: binDirComment,
+  cmd: binDirComment,
+  dist: binDirComment,
+
+  // assets dir variants
+  assets: assetsDirComment,
+  asset: assetsDirComment,
+  public: assetsDirComment,
+};

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -1,4 +1,5 @@
-import { GithubAPIResponseBody, GithubAPIFileObject } from "./types";
+import { GithubAPIResponseBody, GithubAPIFileObject } from './types';
+import { symbols, commonDirComments } from './constants';
 
 // ripOutPaths condenses the response body from a Github API call to a list of directory paths.
 const ripOutPaths = (responseBody: GithubAPIResponseBody): string[] => responseBody.tree
@@ -21,11 +22,13 @@ const ripOutPaths = (responseBody: GithubAPIResponseBody): string[] => responseB
 // at the beginning of the provided dirname.
 //
 // Helper func for generateTree().
-const formatDirName = (path: string, dirName: string): string => `📂 [${dirName}](./${path})`;
+const formatDirName = (path: string, dirName: string): string => {
+  let output = `📂 [${dirName}](./${path})`;
+  if (commonDirComments.hasOwnProperty(path)) {
+    output += ` ${commonDirComments[path]}`;
+  }
 
-const symbols = {
-  branch: '├── ',
-  vertical: '│   ',
+  return output;
 };
 
 // generateTree returns a list of strings --- one string for each line of the output ---


### PR DESCRIPTION
Closes #14 

This PR proposes to introduce new functionality during the "tree printout" generation process: if we recognize a common type of directory, then we add a helpful comment or description next to that folder's name.

See `constants.ts` file to see all of the common directory types that I thought of supporting. If I've missed a common directory that we could support, please write a new key-value pair on the `commonDirComments` object in `constants.ts` and add a new commit onto this branch!