### PR TITLE
Adds Badges to our README Creation!

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import MarkdownDisplay from './components/MarkdownDisplay';
+import BadgesSection from "./components/BadgesSection";
 
 // Styles
 
@@ -21,6 +22,7 @@ const Column = styled.div`
 
 const App: React.FC = () => {
   const [url, setURL] = useState('Enter a Github Repo');
+  const [repoName, setRepoName] = useState('react-ui');
   const [markdownDisplayContent, setMarkdownDisplayContent] = useState(['public', 'src']);
 
   const handleURLChange = (e: React.ChangeEvent<HTMLInputElement>) => setURL(e.target.value);
@@ -30,6 +32,7 @@ const App: React.FC = () => {
       <Column>
         <h1>SWEGGG</h1>
         <input type="text" value={url} onChange={handleURLChange} />
+        <BadgesSection repoName={repoName}/>
         <MarkdownDisplay content={markdownDisplayContent} />
       </Column>
     </Container>

--- a/src/components/BadgesSection.tsx
+++ b/src/components/BadgesSection.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { repoToMarkDownBadge } from '../utils/repoToBadge';
+// Styles
+
+const BadgeDisplay = styled.div`
+  width: 100%;
+`;
+
+const Card = styled.div`
+  width: 100%;
+  padding: 2rem;
+  background: #212428;
+  color: white;
+  margin: 25px 0;
+`;
+
+// Components
+
+interface Props {
+    repoName: string;
+}
+
+const BadgesSection: React.FC<Props> = ({ repoName }: Props) => (
+  <Card>
+    <BadgeDisplay>
+      <a href={`https://badge.fury.io/js/${repoName}`}>
+        <img src={`https://badge.fury.io/js/${repoName}.svg`} alt="npm version" height="18" />
+      </a>
+    </BadgeDisplay>
+    <CopyToClipboard text={repoToMarkDownBadge(repoName)}>
+      <button type="submit">Copy to Clipboard</button>
+    </CopyToClipboard>
+  </Card>
+);
+
+export default BadgesSection;

--- a/src/utils/repoToBadge.ts
+++ b/src/utils/repoToBadge.ts
@@ -1,0 +1,4 @@
+export const repoToMarkDownBadge = (repoName: string): string => {
+    const badgeDisplay = `[![npm version](https://badge.fury.io/js/${repoName}.svg)](https://badge.fury.io/js/${repoName})`;
+    return badgeDisplay;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7469722/83774875-49922680-a654-11ea-864a-2baefd30cfd7.png)


Badges are working (Copy to clipboard produces markDown accessible bage)
Ex: [![npm version](https://badge.fury.io/js/react-ui.svg)](https://badge.fury.io/js/react-ui)

We should say powered by BadgeIo for this though