### PR TITLE
Write a reusable CustomButton component

### DIFF
--- a/src/components/reusable/CustomButton.tsx
+++ b/src/components/reusable/CustomButton.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const CustomButton = styled.input.attrs((props) => ({
+  type: 'submit',
+  value: props.value,
+}))`
+
+  position: relative;
+  top: 0;
+  padding: 1rem 2.5rem;
+
+  color: #212428;
+  background: #fdce03;
+  border: none;
+
+  transition: all 200ms;
+
+  &:hover {
+    cursor: pointer;
+
+    top: -4px;
+    box-shadow: 0px 4px 0px -2px #212428, 0px 8px 0px -4px #fdce03;
+  }
+ 
+  $:active {
+    top: 0;
+    box-shadow: none;
+  }
+`;
+
+export default CustomButton;


### PR DESCRIPTION
This new button component has two `box-shadow`s on hover. This is because the "middle" one is supposed to be the same color as the background that the button is on top of. The "bottom" yellow line is meant to look like it's floating underneath the button.
![Screen Shot 2020-06-04 at 12 32 55 PM](https://user-images.githubusercontent.com/31291920/83785614-8fa0b780-a65f-11ea-84c2-a15cd4cd57dd.png)
