### PR TITLE
Force GitHub to respect newline chars when rendering README

### DIFF
--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -27,7 +27,7 @@ const MarkdownDisplay: React.FC<Props> = (props: Props) => (
     </div>
     <div className="row">
       <CenteredCol className="col">
-        <CopyToClipboard text={props.content.join('\n')}>
+        <CopyToClipboard text={props.content.join('  \n')}>
           <CustomButton type="submit" value="Copy to Clipboard" />
         </CopyToClipboard>
       </CenteredCol>


### PR DESCRIPTION
GitHub markdown doesn't respect newline escape chars when rendering READMEs (or any markdown file, for that matter). This PR proposes to join each line of the "tree printout" with two spaces and a newline instead of just a newline when the "Copy to Clipboard" button is pressed.