### PR TITLE
Write functionality to copy "tree printout" with "markdown hack"

### DIFF
--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -27,7 +27,7 @@ const MarkdownDisplay: React.FC<Props> = (props: Props) => (
     </div>
     <div className="row">
       <CenteredCol className="col">
-        <CopyToClipboard text={props.content.join('  \n')}>
+        <CopyToClipboard text={`<big><pre>\n${props.content.join('\n')}\n</pre></big>}`}>
           <CustomButton type="submit" value="Copy to Clipboard" />
         </CopyToClipboard>
       </CenteredCol>


### PR DESCRIPTION
In Markdown, you can't include relative links inside of code snippet blocks (blocks surrounded with ```). The only way you can get GitHub to render sections of a markdown file with a monospaced font is to put that section in a code snippet block.

We were at a crossroads, until @ralph-dev came to the rescue with a neat GitHub markdown hack! If you surround a code snippet block with `<big><pre> ... </pre></big>`, then you can coerce GitHub to render your snippet with a monospaced font while maintaining support for relative links!

This PR adjusts the functionality of the "markdown display box"'s "copy to clipboard" button: this button copies text surrounded by those `<big>` and `<pre>` tags to the user's clipboard. This way, users can paste what they've copied right into a markdown file, and everything will look and behave as expected