### PR TITLE
Create CustomSecondaryButton --- a small "copy to clipboard" button

### DIFF
--- a/src/components/BadgesSection.tsx
+++ b/src/components/BadgesSection.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Card from './reusable/Card';
 import CenteredCol from './reusable/CenteredCol';
-import CustomButton from './reusable/CustomButton';
+import CustomSecondaryButton from './reusable/CustomSecondaryButton';
 import { repoToMarkDownBadge } from '../utils/repoToBadge';
 
 // Styles
@@ -37,7 +37,7 @@ const BadgesSection: React.FC<Props> = ({ repoName }: Props) => (
     <div className="row">
       <CenteredCol className="col">
         <CopyToClipboard text={repoToMarkDownBadge(repoName)}>
-          <CustomButton type="submit" value="Copy to Clipboard" />
+          <CustomSecondaryButton type="submit" value="Copy to Clipboard" />
         </CopyToClipboard>
       </CenteredCol>
     </div>

--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Card from './reusable/Card';
 import CenteredCol from './reusable/CenteredCol';
-import CustomButton from './reusable/CustomButton';
+import CustomSecondaryButton from './reusable/CustomSecondaryButton';
 import MarkdownDisplayLine from './MarkdownDisplayLine';
 
 interface Props {
@@ -28,7 +28,7 @@ const MarkdownDisplay: React.FC<Props> = (props: Props) => (
     <div className="row">
       <CenteredCol className="col">
         <CopyToClipboard text={`<big><pre>\n${props.content.join('\n')}\n</pre></big>}`}>
-          <CustomButton type="submit" value="Copy to Clipboard" />
+          <CustomSecondaryButton type="submit" value="Copy to Clipboard" />
         </CopyToClipboard>
       </CenteredCol>
     </div>

--- a/src/components/reusable/CustomSecondaryButton.tsx
+++ b/src/components/reusable/CustomSecondaryButton.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+const CustomSecondaryButton = styled.input.attrs((props) => ({
+  type: 'submit',
+  value: props.value,
+  onclick: props.onClick,
+}))`
+
+  position: relative;
+  top: 0;
+  padding: 0.5rem 1.25rem;
+
+  color: #212428;
+  background: #fdce03;
+  font-family: 'Muli';
+  font-size: 0.9rem;
+  border: none;
+
+  transition: all 200ms;
+
+  &:hover {
+    cursor: pointer;
+
+    top: -4px;
+    box-shadow: 0px 4px 0px -2px #212428, 0px 8px 0px -4px #fdce03;
+  }
+ 
+  &:active {
+    top: 0;
+    box-shadow: none;
+  }
+`;
+
+export default CustomSecondaryButton;


### PR DESCRIPTION
<img width="796" alt="Screen Shot 2020-06-04 at 9 21 54 PM" src="https://user-images.githubusercontent.com/31291920/83826447-eaf79780-a6a9-11ea-9fa0-bb9fc9bcf8fe.png">

Related to #10

On our UI, the "go" button is the main call-to-action item, while the "copy to clipboard" buttons are like helpful utility buttons. The "go" button should be larger in size than the "copy to clipboard" buttons.

This PR proposes to add a new reusable component: `CustomSecondaryButton`. Besides the smaller size, this new button is otherwise a clone of the existing `CustomButton` reusable component.