### PR TITLE
Add commenting support for more common directory types

### DIFF
--- a/src/tree/constants.ts
+++ b/src/tree/constants.ts
@@ -10,6 +10,13 @@ const toolsDirComment = `${commentLeader} Miscellaneous helpers and utilities`;
 const docDirComment = `${commentLeader} Documentation files`;
 const binDirComment = `${commentLeader} Compiled files, or standalone executables`;
 const assetsDirComment = `${commentLeader} Supplemental assets or resources, or static files`;
+const exampleDirComment = `${commentLeader} "Real world" examples that demonstrate how this project may be used`;
+const scriptDirComment = `${commentLeader} Small runnables (typically shell scripts) that perform routine tasks`;
+const vscodeDirComment = `${commentLeader} Configurations for Visual Studio Code users`;
+const circleciDirComment = `${commentLeader} Configurations for CI/CD jobs on the CircleCI platform`;
+const githubDirComment = `${commentLeader} Markdown files that GitHub looks for, like changelogs and issue templates`;
+const androidDirComment = `${commentLeader} Native code generated for the Android platform`;
+const iosDirComment = `${commentLeader} Native code generated for the iOS platform`;
 
 export const commonDirComments: Record<string, string> = {
   // src dir variants
@@ -17,11 +24,14 @@ export const commonDirComments: Record<string, string> = {
   lib: srcDirComment,
   app: srcDirComment,
   pkg: srcDirComment,
+  packages: srcDirComment,
 
   // test dir variants
   test: testDirComment,
   tests: testDirComment,
   spec: testDirComment,
+  e2e: testDirComment,
+  jest: testDirComment,
 
   // tools dir variants
   tools: toolsDirComment,
@@ -42,4 +52,28 @@ export const commonDirComments: Record<string, string> = {
   assets: assetsDirComment,
   asset: assetsDirComment,
   public: assetsDirComment,
+
+  // example dir variants
+  example: exampleDirComment,
+  examples: exampleDirComment,
+  guide: exampleDirComment,
+
+  // script dir variants
+  script: scriptDirComment,
+  scripts: scriptDirComment,
+
+  // android dir variants
+  android: androidDirComment,
+
+  // ios dir variants
+  ios: iosDirComment,
+
+  // .vscode dir variants
+  '.vscode': vscodeDirComment,
+
+  // .circleci dir variants
+  '.circleci': circleciDirComment,
+
+  // .github dir variants
+  '.github': githubDirComment,
 };


### PR DESCRIPTION
This PR proposes to add comments for more common directory types that we can reliably guess the purpose of. I was inspired by the common directory types that @ralph-dev mentioned in #17.

If there is a common directory that I didn't include support for in this PR, add a new commit onto this branch and mention it in this discussion!